### PR TITLE
Don't kill our Cloud Function Quota 

### DIFF
--- a/functions/UserPresence.js
+++ b/functions/UserPresence.js
@@ -2,7 +2,7 @@
 var functions = require("firebase-functions");
 var admin = require("firebase-admin");
 
-exports.onUserPresenceChange = functions.database.ref("{room_id}/{uid}").onWrite(
+exports.onUserPresenceChange = functions.database.ref("{room_id}/users/{uid}").onWrite(
     async(change, context) => {
         // If the value dne, then an onDisconnect() delete just occured and they should be
         // removed from the userlist


### PR DESCRIPTION
The Canvas uses Realtime database to store drawing data. I moved the user data to `{room_id}/users/{uid}` and the Canvas data sits at `{room_id}/canvas/{data}`. The function listening for user joins / leaves was still listening on `{room_id}/{uid}` which meant it was fireing basically everytime someone moved their mouse. This prevents that from happening.