### PR TITLE
Fix Random Queue Order

### DIFF
--- a/js/models/Queue.js
+++ b/js/models/Queue.js
@@ -37,7 +37,7 @@ var Queue = {
          * Create a document (queued item) in the queue collection
          */
         Firebase.firestore().collection("room").doc(RoomState.Room_ID)
-            .collection("queue").add({
+            .collection("queue").doc(Firebase.firestore.Timestamp.now().toMillis().toString()).set({
                 url: URL,
                 user: Session.getUid()
             });


### PR DESCRIPTION
Originally was given a random doc name, but now it's set to the current time in milliseconds, and due to the way Firebase orders their docs and collections, the Queue will be ordered by timestamp.