### PR TITLE
Fix toolbar click event imports

### DIFF
--- a/js/views/components/Toolbar/Icon.js
+++ b/js/views/components/Toolbar/Icon.js
@@ -1,7 +1,5 @@
 var m = require("mithril");
 
-var ToolbarState = require("./../../../models/ToolbarState");
-var Toolbar = require("./Toolbar");
 /*
     Invidual tool icon
 */
@@ -10,12 +8,18 @@ var Icon = {
         if(typeof vnode.attrs.color == "undefined" || !vnode.attrs.color) {
             return m("i", {
                 class:"icon active-icon " + vnode.attrs.icon,
-                onclick: () => { ToolbarState.setTool(vnode.attrs.tool); }
+                onclick: () => { 
+                    var ToolbarState = require("./../../../models/ToolbarState");
+                    ToolbarState.setTool(vnode.attrs.tool); 
+                }
             });    
         } else {
             return m("i", {
                 class: "icon active-icon " + vnode.attrs.icon, 
-                onclick: () => {Toolbar.COLOR = 1;}
+                onclick: () => {
+                    var Toolbar = require("./Toolbar");
+                    Toolbar.COLOR = 1; 
+                }
             });
         }
         


### PR DESCRIPTION
These stopped working too. It's something with how webpack decides what to import. I think require removed all the intelligence from it and said to load it no matter what, but it may try to be intelligent about loading and check that the code imported is actually used. Since event listeners aren't included in the procedural-execution flow it might not properly detect them, though I don't know what the conditions are that cause it to sometimes work and sometimes not.

If we had more time on the project, the proper solution would be using import() statements and setting up code splitting in webpack to lazy load / locally cache code.